### PR TITLE
refactor: phone formatting, connect user-del, read academic term

### DIFF
--- a/src/api/admin.api.ts
+++ b/src/api/admin.api.ts
@@ -89,3 +89,19 @@ export const useUserUpdate = () => {
     },
   });
 };
+
+// 유저 삭제
+
+export const useDeleteUser = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (userId: number) => {
+      const res = await apiClient.delete(`/api/admin/users/${userId}`);
+      return res.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin_users"] });
+    },
+  });
+};

--- a/src/pages/admin/user/Users.tsx
+++ b/src/pages/admin/user/Users.tsx
@@ -42,8 +42,9 @@ import { RoleCombobox } from "../../../components/ui/RoleCombobox";
 import { StateCombobox } from "../../../components/ui/StateCombobox";
 import { toast } from "sonner";
 import { Label } from "../../../components/ui/label";
-import { useAdminUsers, useUserUpdate } from "../../../api/admin.api";
+import { useAdminUsers, useUserUpdate, useDeleteUser } from "../../../api/admin.api";
 import { useRegisterExcel } from "../../../api/adminUser.api";
+import { useAcademicTerms } from "../../../api/academicTerm.api";
 
 const Users = () => {
   const navigte = useNavigate();
@@ -60,11 +61,40 @@ const Users = () => {
   const [excelPreviewData, setExcelPreviewData] = useState<unknown>(null);
   const [page, setPage] = useState(0);
   const size = 10;
+  const formatPhoneNumber = (phone?: string) => {
+    if (!phone) return "";
+  
+    const digits = phone.replace(/\D/g, "");
+  
+    if (digits.length === 11) {
+      return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
+    }
+  
+    if (digits.length === 10) {
+      return `${digits.slice(0, 3)}-${digits.slice(3, 6)}-${digits.slice(6)}`;
+    }
+  
+    return phone;
+  };
+
+  const formatAcademicTermLabel = (term: {
+    year: number;
+    term: "SPRING" | "FALL";
+    active: boolean;
+  }) => {
+    const semesterText = term.term === "SPRING" ? "1학기" : "2학기";
+    return `${term.year}-${semesterText}${term.active ? " (현재 학기)" : ""}`;
+  };
 
   const { mutateAsync: registerExcel, isPending: isRegisteringExcel } =
     useRegisterExcel();
+  
+  const { data: academicTerms = [], isLoading: isAcademicTermsLoading } =
+    useAcademicTerms();
 
   const { mutate: updateUser, isPending: isUpdating } = useUserUpdate();
+  const { mutate: deleteUser, isPending: isDeletingUser } = useDeleteUser();
+
   const [checkedRoles, setCheckedRoles] = useState({
     ADMIN: true,
     USER: true,
@@ -135,6 +165,16 @@ const Users = () => {
     setEditPhone(selectedUser.phone);
   }, [selectedUser]);
 
+  useEffect(() => {
+    if (!academicTerms.length) return;
+    if (excelTermId) return;
+  
+    const activeTerm = academicTerms.find((term) => term.active);
+    if (activeTerm) {
+      setExcelTermId(String(activeTerm.id));
+    }
+  }, [academicTerms, excelTermId]);
+
   const handleUpdateUser = () => {
     if (!selectedUser) {
       toast("수정할 사용자를 선택해주세요.");
@@ -161,6 +201,23 @@ const Users = () => {
     );
   };
 
+  const handleDeleteUser = () => {
+    if (!selectedUser) {
+      toast("삭제할 사용자를 선택해주세요.");
+      return;
+    }
+  
+    deleteUser(selectedUser.userId, {
+      onSuccess: () => {
+        toast("해당 사용자가 삭제되었습니다.");
+        setSelectedUserId(null);
+      },
+      onError: () => {
+        toast("사용자 삭제에 실패했습니다.");
+      },
+    });
+  };
+
   const resetExcelForm = () => {
     setExcelTermId("");
     setExcelFile(null);
@@ -169,7 +226,7 @@ const Users = () => {
 
   const handleExcelPreview = async () => {
     if (!excelTermId.trim()) {
-      toast.error("학기 ID를 입력해주세요.");
+      toast.error("학기를 선택해주세요.");
       return;
     }
 
@@ -194,7 +251,7 @@ const Users = () => {
 
   const handleExcelConfirm = async () => {
     if (!excelTermId.trim()) {
-      toast.error("학기 ID를 입력해주세요.");
+      toast.error("학기를 선택해주세요.");
       return;
     }
 
@@ -279,16 +336,24 @@ const Users = () => {
               </AlertDialogHeader>
 
               <div className="space-y-4 pt-4">
-                <div>
-                  <Label className="pb-2">학기 ID</Label>
-                  <Input
-                    type="number"
-                    value={excelTermId}
-                    onChange={(e) => setExcelTermId(e.target.value)}
-                    placeholder="예: 4"
-                  />
-                </div>
-
+              <div>
+                <Label className="pb-2">학기 선택</Label>
+                <select
+                  value={excelTermId}
+                  onChange={(e) => setExcelTermId(e.target.value)}
+                  disabled={isAcademicTermsLoading}
+                  className="w-full rounded-md border border-neutral-400 bg-[#060a0c] px-3 py-2 text-sm text-white"
+                >
+                  <option value="">
+                    {isAcademicTermsLoading ? "학기 불러오는 중..." : "학기를 선택해주세요."}
+                  </option>
+                  {academicTerms.map((term) => (
+                    <option key={term.id} value={term.id}>
+                      {formatAcademicTermLabel(term)}
+                    </option>
+                  ))}
+                </select>
+              </div>
                 <div>
                   <Label className="pb-2">엑셀 파일</Label>
                   <Input
@@ -470,33 +535,49 @@ const Users = () => {
           </div>
           {/* 삭제 버튼 */}
           <div>
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <div className="border cursor-pointer px-3 py-1 rounded-sm hover:bg-red-400 hover:text-black border-red-400 text-sm text-red-300">
-                  삭제
-                </div>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>
-                    #1 이서연을 삭제하시겠습니까?
-                  </AlertDialogTitle>
-                </AlertDialogHeader>
-
-                <AlertDialogFooter className="mt-4">
-                  <AlertDialogCancel className="cursor-pointer">
-                    취소
-                  </AlertDialogCancel>
-                  <AlertDialogAction
-                    onClick={() => toast("해당 사용자가 삭제되었습니다.")}
-                    className="bg-red-600 hover:bg-red-500 font-bold cursor-pointer"
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <button
+                    type="button"
+                    disabled={!selectedUser}
+                    className={`border px-3 py-1 rounded-sm text-sm ${
+                      selectedUser
+                        ? "cursor-pointer hover:bg-red-400 hover:text-black border-red-400 text-red-300"
+                        : "cursor-not-allowed border-neutral-700 text-neutral-600"
+                    }`}
                   >
                     삭제
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-          </div>
+                  </button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>
+                      {selectedUser
+                        ? `#${selectedUser.userId} ${selectedUser.username}을(를) 삭제하시겠습니까?`
+                        : "삭제할 사용자를 선택해주세요."}
+                    </AlertDialogTitle>
+                    <AlertDialogDescription>
+                      {selectedUser
+                        ? "사용자를 삭제하면 되돌릴 수 없습니다."
+                        : "테이블에서 삭제할 사용자를 선택해주세요."}
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+
+                  <AlertDialogFooter className="mt-4">
+                    <AlertDialogCancel className="cursor-pointer">
+                      취소
+                    </AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={handleDeleteUser}
+                      disabled={!selectedUser || isDeletingUser}
+                      className="bg-red-600 hover:bg-red-500 font-bold cursor-pointer"
+                    >
+                      {isDeletingUser ? "삭제 중..." : "삭제"}
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            </div>
         </div>
       </div>
       {/* 권한 체크박스 */}
@@ -619,7 +700,7 @@ const Users = () => {
                   </TableCell>
                   <TableCell>{user.state}</TableCell>
                   <TableCell>{user.email}</TableCell>
-                  <TableCell>{user.phone}</TableCell>
+                  <TableCell>{formatPhoneNumber(user.phone)}</TableCell>
                 </TableRow>
               ))
             )}


### PR DESCRIPTION
1. 관리자 사용자 목록에서 연락처가 숫자만 보이던 부분을 010-0000-0000 형식으로 포맷팅하여 표시되도록 수정
2. 관리자 사용자 관리 화면에서 선택한 사용자를 삭제할 수 있도록 삭제 API 연동
3. 학생 정보 엑셀 일괄 등록 모달에서 학기 ID를 직접 입력하던 방식을 학기 조회 API 기반 드롭다운 선택 방식으로 개선학기 4. 드롭다운에는 2026-1학기, 2026-2학기 형식으로 표시되도록 가공하고, 현재 활성 학기가 있을 경우 기본 선택되도록 반영
5. 엑셀 등록 시 학기 관련 안내 문구를 ID 입력 기준에서 학기 선택 기준으로 변경


[유저 삭제 연동 사진입니다!!]
<img width="750" height="787" alt="스크린샷 2026-05-04 오전 11 58 35" src="https://github.com/user-attachments/assets/df159d8f-21a7-4d7d-a6e0-6598585d6fe4" />


[엑셀 등록 학기 ID -> 학기 선택으로 변경한 사진입니다.]
<img width="747" height="737" alt="스크린샷 2026-05-04 오전 11 58 22" src="https://github.com/user-attachments/assets/cb449e19-747c-4238-b987-ac39cfd428fe" />