### PR TITLE
fix: putmapping, index problem

### DIFF
--- a/src/api/admin.api.ts
+++ b/src/api/admin.api.ts
@@ -74,8 +74,7 @@ export const useUserUpdate = () => {
       email,
       phone,
     }: UpdateUserRequest) => {
-      const res = await apiClient.put(`/api/admin/users/${userId}`, {
-        userId,
+      const res = await apiClient.patch(`/api/admin/users/${userId}`, {
         role,
         state,
         email,

--- a/src/pages/admin/checkin/ManualRental.tsx
+++ b/src/pages/admin/checkin/ManualRental.tsx
@@ -76,6 +76,22 @@ const ManualRental = () => {
   const { data: availableItems = [], isLoading: isAvailableItemsLoading } =
     useItemAvailable(selectedModelId);
 
+  const formatPhoneNumber = (phone?: string) => {
+    if (!phone) return "";
+    
+    const digits = phone.replace(/\D/g, "");
+    
+    if (digits.length === 11) {
+      return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
+    }
+    
+    if (digits.length === 10) {
+      return `${digits.slice(0, 3)}-${digits.slice(3, 6)}-${digits.slice(6)}`;
+    }
+    
+    return phone;
+  };
+
   const rolesParam = useMemo(() => {
     const roles: string[] = [];
     if (checkedRoles.ADMIN) roles.push("ADMIN");
@@ -427,7 +443,7 @@ const ManualRental = () => {
           <TableHeader className="text-center border-b bg-[#11141b] hover:bg-[#11141b] border-neutral-700">
             <TableRow>
               <TableHead></TableHead>
-              <TableHead className="text-white text-center">ID</TableHead>
+              <TableHead className="text-white text-center">순번</TableHead>
               <TableHead className="text-white text-center">이름</TableHead>
               <TableHead className="text-white text-center">학번</TableHead>
               <TableHead className="text-white text-center">권한</TableHead>
@@ -460,7 +476,7 @@ const ManualRental = () => {
                 </TableCell>
               </TableRow>
             ) : (
-              users.map((user) => (
+              users.map((user, index) => (
                 <TableRow key={user.userId}>
                   <TableCell onClick={(e) => e.stopPropagation()}>
                     <Checkbox
@@ -470,7 +486,7 @@ const ManualRental = () => {
                       }
                     />
                   </TableCell>
-                  <TableCell>{user.userId}</TableCell>
+                  <TableCell>{currentPage * USERS_PAGE_SIZE + index + 1}</TableCell>
                   <TableCell>{user.username}</TableCell>
                   <TableCell>{user.studentId}</TableCell>
                   <TableCell>
@@ -478,7 +494,7 @@ const ManualRental = () => {
                   </TableCell>
                   <TableCell>{user.state}</TableCell>
                   <TableCell>{user.email}</TableCell>
-                  <TableCell>{user.phone}</TableCell>
+                  <TableCell>{formatPhoneNumber(user.phone)}</TableCell>
                 </TableRow>
               ))
             )}

--- a/src/pages/admin/user/Users.tsx
+++ b/src/pages/admin/user/Users.tsx
@@ -678,7 +678,7 @@ const Users = () => {
                 </TableCell>
               </TableRow>
             ) : (
-              users.map((user) => (
+              users.map((user, index) => (
                 <TableRow
                   key={user.userId}
                   className="cursor-pointer"
@@ -692,7 +692,7 @@ const Users = () => {
                       }}
                     />
                   </TableCell>
-                  <TableCell>{user.userId}</TableCell>
+                  <TableCell>{page * size + index + 1}</TableCell>
                   <TableCell>{user.username}</TableCell>
                   <TableCell>{user.studentId}</TableCell>
                   <TableCell>


### PR DESCRIPTION
사용자 정보 수정 API 연동 방식 변경
    * 백엔드 사용자 수정 API가 PUT에서 PATCH로 변경됨에 따라 프론트 요청 메서드도 PUT → PATCH로 수정
    * 사용자 수정 기능이 변경된 API 스펙에 맞게 정상 동작하도록 반영
    
* 사용자 관리 / 수기 대여 등록 화면 전화번호 표기 방식 개선
    * DB에는 전화번호가 하이픈 없이 저장되어 있으므로, 사용자 조회 화면과 수기 대여 등록 화면에서는 화면 표시 시 하이픈이 포함된 형태로 변환하여 보여주도록 수정
    * 예: 01026009053 → 010-2600-9053
    제가 사용자 조회쪽은 바꿨었는데, 수기 대여 테이블은 수정안했어서 같이 수정했습니다!

* 사용자 목록 화면 식별자 표시 방식 개선
    * 기존에는 사용자 테이블에서 DB PK(userId)를 그대로 노출하고 있었음
    * 실무자 사용성을 고려하여 PK 대신 목록상의 순번(Index)을 표시하도록 변경
    * 페이지네이션을 고려하여 현재 페이지 기준 순번이 아닌 전체 목록 기준 순번으로 표시되도록 반영
    
    DB에서 사용하는 user-id pk로 정렬이 되서 페이지네이션 순번으로 변경했습니다!