### PR TITLE
학기 설정 기능 확장 및 관리자 UI 문구 정리

### DIFF
--- a/src/api/academicTerm.api.ts
+++ b/src/api/academicTerm.api.ts
@@ -29,6 +29,8 @@ export const useCreateAcademicTerm = () => {
     mutationFn: async ({
       year,
       term,
+      startDate,
+      reservationOpenAt,
       endDate,
       active,
     }: CreateAcademicTermRequest) => {
@@ -37,6 +39,8 @@ export const useCreateAcademicTerm = () => {
         {
           year,
           term,
+          startDate,
+          reservationOpenAt,
           endDate,
           active,
         },
@@ -75,12 +79,16 @@ export const useUpdateAcademicTerm = () => {
       termId,
       year,
       term,
+      startDate,
+      reservationOpenAt,
       endDate,
       active,
     }: {
       termId: number;
       year: number;
       term: string;
+      startDate: string;
+      reservationOpenAt: string;
       endDate: string;
       active: boolean;
     }) => {
@@ -89,6 +97,8 @@ export const useUpdateAcademicTerm = () => {
         {
           year,
           term,
+          startDate,
+          reservationOpenAt,
           endDate,
           active,
         },

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -70,9 +70,9 @@ const items: NavItem[] = [
     ],
   },
   {
-    title: "종강일 설정",
+    title: "학기 설정",
     icon: CalendarClock,
-    children: [{ title: "종강일 설정", url: "/admin/view-limit" }],
+    children: [{ title: "학기 정보 관리", url: "/admin/view-limit" }],
   },
 ];
 

--- a/src/pages/admin/limit/ViewLimit.tsx
+++ b/src/pages/admin/limit/ViewLimit.tsx
@@ -46,8 +46,17 @@ import {
 } from "../../../api/academicTerm.api";
 
 const ViewLimit = () => {
-  const [open, setOpen] = useState(false);
-  const [date, setDate] = useState<Date | undefined>(undefined);
+  const [startDateOpen, setStartDateOpen] = useState(false);
+  const [endDateOpen, setEndDateOpen] = useState(false);
+  const [reservationOpenDateOpen, setReservationOpenDateOpen] = useState(false);
+
+  const [startDate, setStartDate] = useState<Date | undefined>(undefined);
+  const [endDate, setEndDate] = useState<Date | undefined>(undefined);
+  const [reservationOpenDate, setReservationOpenDate] = useState<Date | undefined>(
+    undefined,
+  );
+  const [reservationOpenTime, setReservationOpenTime] = useState("09:00");
+
   const [year, setYear] = useState("");
   const [selectedTerm, setSelectedTerm] = useState("");
   const [active, setActive] = useState("false");
@@ -68,6 +77,50 @@ const ViewLimit = () => {
     return `${year}-${month}-${day}`;
   };
 
+  const formatDateTimeString = (date: Date, time: string) => {
+    const [hour, minute] = time.split(":");
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+  
+    return `${year}-${month}-${day}T${hour}:${minute}:00`;
+  };
+  
+  const formatDateLabel = (value: string) => {
+    if (!value) return "";
+  
+    const date = new Date(value);
+  
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+  
+    return `${year}년 ${month}월 ${day}일`;
+  };
+  
+  const formatTimeKoreanLabel = (value: string) => {
+    if (!value) return "";
+  
+    const date = new Date(value);
+    const hour = date.getHours();
+    const minute = date.getMinutes();
+  
+    const period = hour < 12 ? "오전" : "오후";
+    const displayHour = hour % 12 === 0 ? 12 : hour % 12;
+  
+    if (minute === 0) {
+      return `${period} ${displayHour}시`;
+    }
+  
+    return `${period} ${displayHour}시 ${minute}분`;
+  };
+  
+  const formatReservationOpenAtLabel = (value: string) => {
+    if (!value) return "";
+  
+    return `${formatDateLabel(value)}     ${formatTimeKoreanLabel(value)}`;
+  };
+
   const handleCreateAcademicTerm = () => {
     if (!year.trim()) {
       toast("년도를 입력해주세요.");
@@ -79,8 +132,18 @@ const ViewLimit = () => {
       return;
     }
 
-    if (!date) {
-      toast("날짜를 선택해주세요.");
+    if (!startDate) {
+      toast("개강일을 선택해주세요.");
+      return;
+    }
+    
+    if (!reservationOpenDate) {
+      toast("기자재 신청 시작 날짜를 선택해주세요.");
+      return;
+    }
+    
+    if (!endDate) {
+      toast("종강일을 선택해주세요.");
       return;
     }
 
@@ -88,19 +151,27 @@ const ViewLimit = () => {
       {
         year: Number(year),
         term: selectedTerm,
-        endDate: formatDateToKSTString(date),
+        startDate: formatDateToKSTString(startDate),
+        reservationOpenAt: formatDateTimeString(
+          reservationOpenDate,
+          reservationOpenTime,
+        ),
+        endDate: formatDateToKSTString(endDate),
         active: active === "true",
       },
       {
         onSuccess: () => {
-          toast("종강일이 추가되었습니다.");
+          toast("학기 정보가 추가되었습니다.");
           setYear("");
           setSelectedTerm("");
-          setDate(undefined);
+          setStartDate(undefined);
+          setEndDate(undefined);
+          setReservationOpenDate(undefined);
+          setReservationOpenTime("09:00");
           setActive("false");
         },
         onError: () => {
-          toast("종강일 추가에 실패했습니다.");
+          toast("학기 정보 추가에 실패했습니다.");
         },
       },
     );
@@ -117,11 +188,11 @@ const ViewLimit = () => {
 
     deleteAcademicTerm(selectedTermId, {
       onSuccess: () => {
-        toast("해당 종강일이 삭제되었습니다.");
+        toast("해당 학기 정보가 삭제되었습니다.");
         setSelectedTermId(null);
       },
       onError: () => {
-        toast("종강일 삭제에 실패했습니다.");
+        toast("학기 정보 삭제에 실패했습니다.");
       },
     });
   };
@@ -134,11 +205,32 @@ const ViewLimit = () => {
 
     setYear(String(selectedAcademicTerm.year));
     setSelectedTerm(selectedAcademicTerm.term);
-    setDate(
+
+    setStartDate(
+      selectedAcademicTerm.startDate
+        ? new Date(selectedAcademicTerm.startDate)
+        : undefined,
+    );
+
+    setEndDate(
       selectedAcademicTerm.endDate
         ? new Date(selectedAcademicTerm.endDate)
         : undefined,
     );
+
+    if (selectedAcademicTerm.reservationOpenAt) {
+      const reservationDate = new Date(selectedAcademicTerm.reservationOpenAt);
+      setReservationOpenDate(reservationDate);
+      setReservationOpenTime(
+        `${String(reservationDate.getHours()).padStart(2, "0")}:${String(
+          reservationDate.getMinutes(),
+        ).padStart(2, "0")}`,
+      );
+    } else {
+      setReservationOpenDate(undefined);
+      setReservationOpenTime("09:00");
+    }
+
     setActive(selectedAcademicTerm.active ? "true" : "false");
   };
 
@@ -158,8 +250,18 @@ const ViewLimit = () => {
       return;
     }
 
-    if (!date) {
-      toast("날짜를 선택해주세요.");
+    if (!startDate) {
+      toast("개강일을 선택해주세요.");
+      return;
+    }
+    
+    if (!reservationOpenDate) {
+      toast("기자재 신청 시작 날짜를 선택해주세요.");
+      return;
+    }
+    
+    if (!endDate) {
+      toast("종강일을 선택해주세요.");
       return;
     }
 
@@ -168,20 +270,28 @@ const ViewLimit = () => {
         termId: selectedAcademicTerm.id,
         year: Number(year),
         term: selectedTerm,
-        endDate: formatDateToKSTString(date),
+        startDate: formatDateToKSTString(startDate),   
+        reservationOpenAt: formatDateTimeString(
+          reservationOpenDate,
+          reservationOpenTime,
+        ),
+        endDate: formatDateToKSTString(endDate),
         active: active === "true",
       },
       {
         onSuccess: () => {
-          toast("종강일이 수정되었습니다.");
+          toast("학기 정보가 수정되었습니다.");
           setYear("");
           setSelectedTerm("");
-          setDate(undefined);
+          setStartDate(undefined);
+          setEndDate(undefined);
+          setReservationOpenDate(undefined);
+          setReservationOpenTime("09:00");
           setActive("false");
           setSelectedTermId(null);
         },
         onError: () => {
-          toast("종강일 수정에 실패했습니다.");
+          toast("학기 정보 수정에 실패했습니다.");
         },
       },
     );
@@ -204,7 +314,7 @@ const ViewLimit = () => {
             <BreadcrumbSeparator />
             <BreadcrumbItem>
               <BreadcrumbPage className="text-white">
-                종강일 설정 현황
+                학기 설정
               </BreadcrumbPage>
             </BreadcrumbItem>
           </BreadcrumbList>
@@ -213,11 +323,11 @@ const ViewLimit = () => {
 
       <div className="pt-8">
         <div className="font-bold text-white text-3xl pb-8">
-          종강일 설정 현황
+          학기 설정
         </div>
 
         <div className="flex space-x-4 justify-end">
-          {/* 종강일 추가 버튼 */}
+          {/* 학기 추가 버튼 */}
           <AlertDialog>
             <AlertDialogTrigger asChild>
               <div className="border cursor-pointer px-3 py-1 rounded-sm hover:bg-neutral-400 hover:text-black border-neutral-400 text-sm">
@@ -226,9 +336,9 @@ const ViewLimit = () => {
             </AlertDialogTrigger>
             <AlertDialogContent>
               <AlertDialogHeader>
-                <AlertDialogTitle>종강일 추가</AlertDialogTitle>
+                <AlertDialogTitle>학기 추가</AlertDialogTitle>
                 <AlertDialogDescription>
-                  새 종강일을 추가하면 됩니다.
+                  새 학기 정보를 등록합니다.
                 </AlertDialogDescription>
               </AlertDialogHeader>
 
@@ -251,11 +361,11 @@ const ViewLimit = () => {
                 </div>
 
                 <div>
-                  <Label className="pb-2">날짜</Label>
-                  <Popover open={open} onOpenChange={setOpen}>
+                  <Label className="pb-2">개강일</Label>
+                  <Popover open={startDateOpen} onOpenChange={setStartDateOpen}>
                     <PopoverTrigger asChild>
                       <div className="inline-block w-fit border text-sm rounded-sm px-3 py-1 cursor-pointer">
-                        {date ? date.toLocaleDateString() : "날짜 선택"}
+                        {startDate ? startDate.toLocaleDateString() : "날짜 선택"}
                       </div>
                     </PopoverTrigger>
 
@@ -265,11 +375,81 @@ const ViewLimit = () => {
                     >
                       <Calendar
                         mode="single"
-                        selected={date}
+                        selected={startDate}
                         captionLayout="dropdown"
                         onSelect={(d) => {
-                          setDate(d);
-                          setOpen(false);
+                          setStartDate(d);
+                          setStartDateOpen(false);
+                        }}
+                      />
+                    </PopoverContent>
+                  </Popover>
+                </div>
+
+                <div>
+                  <Label className="pb-2">기자재 신청 시작 일시</Label>
+                  <p className="text-xs text-neutral-400 pb-2">
+                    학생들이 온라인으로 기자재 예약 신청을 시작할 수 있는 시점입니다.
+                  </p>
+
+                  <div className="flex items-center gap-3">
+                    <Popover
+                      open={reservationOpenDateOpen}
+                      onOpenChange={setReservationOpenDateOpen}
+                    >
+                      <PopoverTrigger asChild>
+                        <div className="inline-block w-fit border text-sm rounded-sm px-3 py-1 cursor-pointer">
+                          {reservationOpenDate
+                            ? reservationOpenDate.toLocaleDateString()
+                            : "날짜 선택"}
+                        </div>
+                      </PopoverTrigger>
+
+                      <PopoverContent
+                        className="w-auto rounded-2xl overflow-hidden p-0 bg-white text-black border border-black/10"
+                        align="start"
+                      >
+                        <Calendar
+                          mode="single"
+                          selected={reservationOpenDate}
+                          captionLayout="dropdown"
+                          onSelect={(d) => {
+                            setReservationOpenDate(d);
+                            setReservationOpenDateOpen(false);
+                          }}
+                        />
+                      </PopoverContent>
+                    </Popover>
+
+                    <Input
+                      type="time"
+                      className="w-40"
+                      value={reservationOpenTime}
+                      onChange={(e) => setReservationOpenTime(e.target.value)}
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <Label className="pb-2">종강일</Label>
+                  <Popover open={endDateOpen} onOpenChange={setEndDateOpen}>
+                    <PopoverTrigger asChild>
+                      <div className="inline-block w-fit border text-sm rounded-sm px-3 py-1 cursor-pointer">
+                        {endDate ? endDate.toLocaleDateString() : "날짜 선택"}
+                      </div>
+                    </PopoverTrigger>
+
+                    <PopoverContent
+                      className="w-auto rounded-2xl overflow-hidden p-0 bg-white text-black border border-black/10"
+                      align="start"
+                    >
+                      <Calendar
+                        mode="single"
+                        selected={endDate}
+                        captionLayout="dropdown"
+                        onSelect={(d) => {
+                          setEndDate(d);
+                          setEndDateOpen(false);
                         }}
                       />
                     </PopoverContent>
@@ -303,7 +483,7 @@ const ViewLimit = () => {
             </AlertDialogContent>
           </AlertDialog>
 
-          {/* 종강일 수정 버튼 */}
+          {/* 학기 수정 버튼 */}
           <AlertDialog>
             <AlertDialogTrigger asChild>
               <div
@@ -319,9 +499,9 @@ const ViewLimit = () => {
             </AlertDialogTrigger>
             <AlertDialogContent>
               <AlertDialogHeader>
-                <AlertDialogTitle>종강일 수정</AlertDialogTitle>
+                <AlertDialogTitle>학기 정보 수정</AlertDialogTitle>
                 <AlertDialogDescription>
-                  선택한 종강일 정보를 수정합니다.
+                  선택한 학기 정보를 수정합니다.
                 </AlertDialogDescription>
               </AlertDialogHeader>
 
@@ -344,11 +524,11 @@ const ViewLimit = () => {
                 </div>
 
                 <div>
-                  <Label className="pb-2">날짜</Label>
-                  <Popover open={open} onOpenChange={setOpen}>
+                  <Label className="pb-2">개강일</Label>
+                  <Popover open={startDateOpen} onOpenChange={setStartDateOpen}>
                     <PopoverTrigger asChild>
                       <div className="inline-block w-fit border text-sm rounded-sm px-3 py-1 cursor-pointer">
-                        {date ? date.toLocaleDateString() : "날짜 선택"}
+                        {startDate ? startDate.toLocaleDateString() : "날짜 선택"}
                       </div>
                     </PopoverTrigger>
 
@@ -358,11 +538,81 @@ const ViewLimit = () => {
                     >
                       <Calendar
                         mode="single"
-                        selected={date}
+                        selected={startDate}
                         captionLayout="dropdown"
                         onSelect={(d) => {
-                          setDate(d);
-                          setOpen(false);
+                          setStartDate(d);
+                          setStartDateOpen(false);
+                        }}
+                      />
+                    </PopoverContent>
+                  </Popover>
+                </div>
+
+                <div>
+                  <Label className="pb-2">기자재 신청 시작 일시</Label>
+                  <p className="text-xs text-neutral-400 pb-2">
+                    학생들이 온라인으로 기자재 예약 신청을 시작할 수 있는 시점입니다.
+                  </p>
+
+                  <div className="flex items-center gap-3">
+                    <Popover
+                      open={reservationOpenDateOpen}
+                      onOpenChange={setReservationOpenDateOpen}
+                    >
+                      <PopoverTrigger asChild>
+                        <div className="inline-block w-fit border text-sm rounded-sm px-3 py-1 cursor-pointer">
+                          {reservationOpenDate
+                            ? reservationOpenDate.toLocaleDateString()
+                            : "날짜 선택"}
+                        </div>
+                      </PopoverTrigger>
+
+                      <PopoverContent
+                        className="w-auto rounded-2xl overflow-hidden p-0 bg-white text-black border border-black/10"
+                        align="start"
+                      >
+                        <Calendar
+                          mode="single"
+                          selected={reservationOpenDate}
+                          captionLayout="dropdown"
+                          onSelect={(d) => {
+                            setReservationOpenDate(d);
+                            setReservationOpenDateOpen(false);
+                          }}
+                        />
+                      </PopoverContent>
+                    </Popover>
+
+                    <Input
+                      type="time"
+                      className="w-40"
+                      value={reservationOpenTime}
+                      onChange={(e) => setReservationOpenTime(e.target.value)}
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <Label className="pb-2">종강일</Label>
+                  <Popover open={endDateOpen} onOpenChange={setEndDateOpen}>
+                    <PopoverTrigger asChild>
+                      <div className="inline-block w-fit border text-sm rounded-sm px-3 py-1 cursor-pointer">
+                        {endDate ? endDate.toLocaleDateString() : "날짜 선택"}
+                      </div>
+                    </PopoverTrigger>
+
+                    <PopoverContent
+                      className="w-auto rounded-2xl overflow-hidden p-0 bg-white text-black border border-black/10"
+                      align="start"
+                    >
+                      <Calendar
+                        mode="single"
+                        selected={endDate}
+                        captionLayout="dropdown"
+                        onSelect={(d) => {
+                          setEndDate(d);
+                          setEndDateOpen(false);
                         }}
                       />
                     </PopoverContent>
@@ -396,7 +646,7 @@ const ViewLimit = () => {
             </AlertDialogContent>
           </AlertDialog>
 
-          {/* 종강일 삭제 버튼 */}
+          {/* 학기 삭제 버튼 */}
           <AlertDialog>
             <AlertDialogTrigger asChild>
               <div
@@ -413,14 +663,13 @@ const ViewLimit = () => {
               <AlertDialogHeader>
                 <AlertDialogTitle>
                   {selectedAcademicTerm
-                    ? `${selectedAcademicTerm.code} 종강일을 삭제하시겠습니까?`
-                    : "종강일을 삭제하시겠습니까?"}
+                    ? `${selectedAcademicTerm.code} 학기 정보를 삭제하시겠습니까?`
+                    : "학기 정보를 삭제하시겠습니까?"}
                 </AlertDialogTitle>
                 <AlertDialogDescription>
                   {selectedAcademicTerm ? (
                     <>
-                      {selectedAcademicTerm.code}의 종강일은{" "}
-                      <strong>'{selectedAcademicTerm.endDate}'</strong>입니다.
+                      {selectedAcademicTerm.code} 학기 정보가 삭제됩니다.
                     </>
                   ) : (
                     "삭제할 학기를 먼저 선택해주세요."
@@ -441,7 +690,7 @@ const ViewLimit = () => {
           </AlertDialog>
         </div>
 
-        {/* 종강일 테이블 */}
+        {/* 학기 테이블 */}
         <div className="mt-4">
           <Table className="text-white text-center border border-neutral-700">
             <TableHeader className="text-center border-b bg-[#11141b] hover:bg-[#11141b] border-neutral-700">
@@ -449,7 +698,11 @@ const ViewLimit = () => {
                 <TableHead></TableHead>
                 <TableHead className="text-white text-center">년도</TableHead>
                 <TableHead className="text-white text-center">학기</TableHead>
-                <TableHead className="text-white text-center">날짜</TableHead>
+                <TableHead className="text-white text-center">개강일</TableHead>
+                <TableHead className="text-white text-center">
+                  기자재 신청 시작 일시
+                </TableHead>
+                <TableHead className="text-white text-center">종강일</TableHead>
                 <TableHead className="text-white text-center">
                   현재 학기
                 </TableHead>
@@ -459,14 +712,14 @@ const ViewLimit = () => {
             <TableBody className="cursor-pointer">
               {isLoading ? (
                 <TableRow>
-                  <TableCell colSpan={5} className="text-center py-6">
+                  <TableCell colSpan={7} className="text-center py-6">
                     불러오는 중...
                   </TableCell>
                 </TableRow>
               ) : isError ? (
                 <TableRow>
                   <TableCell
-                    colSpan={5}
+                    colSpan={7}
                     className="text-center py-6 text-red-300"
                   >
                     학기 목록을 불러오지 못했습니다.
@@ -474,8 +727,8 @@ const ViewLimit = () => {
                 </TableRow>
               ) : academicTerms.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={5} className="text-center py-6">
-                    등록된 종강일이 없습니다.
+                  <TableCell colSpan={7} className="text-center py-6">
+                    등록된 학기 정보가 없습니다.
                   </TableCell>
                 </TableRow>
               ) : (
@@ -490,8 +743,10 @@ const ViewLimit = () => {
                       />
                     </TableCell>
                     <TableCell>{term.year}</TableCell>
-                    <TableCell>{term.code}</TableCell>
-                    <TableCell>{term.endDate}</TableCell>
+                    <TableCell>{term.term === "SPRING" ? "1학기" : "2학기"}</TableCell>
+                    <TableCell>{formatDateLabel(term.startDate)}</TableCell>
+                    <TableCell>{formatReservationOpenAtLabel(term.reservationOpenAt)}</TableCell>
+                    <TableCell>{formatDateLabel(term.endDate)}</TableCell>
                     <TableCell>{term.active ? "O" : ""}</TableCell>
                   </TableRow>
                 ))

--- a/src/type/academicTerm.type.ts
+++ b/src/type/academicTerm.type.ts
@@ -3,6 +3,8 @@ export type AcademicTerm = {
   year: number;
   term: string;
   code: string;
+  startDate: string;
+  reservationOpenAt: string;
   endDate: string;
   active: boolean;
 };
@@ -17,6 +19,8 @@ export type ApiResponse<T> = {
 export type CreateAcademicTermRequest = {
   year: number;
   term: string;
+  startDate: string;
+  reservationOpenAt: string;
   endDate: string;
   active: boolean;
 };


### PR DESCRIPTION
작업 내용
1. src/type/academicTerm.type.ts
    AcademicTerm 타입 및 생성 요청 타입에 startDate, reservationOpenAt 추가

2. src/api/academicTerm.api.ts
    학기 생성/수정 API 요청 body에 startDate, reservationOpenAt 반영

3. src/pages/admin/.../ViewLimit.tsx
    종강일 설정 화면을 학기 설정 화면으로 개편
    생성/수정 모달 입력 필드 확장
    테이블 컬럼 및 표시 형식 수정
    관련 문구 및 토스트 메시지 수정