### PR TITLE
feat: 학생 대여 화면 및 관리자 기자재 관리 UI 개선

### DIFF
--- a/src/api/adminModel.api.ts
+++ b/src/api/adminModel.api.ts
@@ -1,44 +1,110 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "./client";
+
+type CreateOrUpdateModelRequest = {
+  categoryName: string;
+  type: string;
+  name: string;
+  displayName: string;
+  subName: string;
+  description: string;
+  visibleToUsers: boolean;
+  courseName: string;
+  totalQty: number;
+  serials: string[];
+  qtyAndSerialsSizeMatching?: boolean;
+};
+
+type UpdateModelRequest = CreateOrUpdateModelRequest & {
+  modelId: number;
+};
 
 // 모델 등록
 export const useCreateModel = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: async ({
       categoryName,
       type,
       name,
+      displayName,
+      subName,
+      description,
+      visibleToUsers,
       courseName,
       totalQty,
       serials,
       qtyAndSerialsSizeMatching,
-    }: {
-      categoryName: string;
-      type: string;
-      name: string;
-      courseName: string;
-      totalQty: number;
-      serials: string[];
-      qtyAndSerialsSizeMatching: boolean;
-    }) => {
-      const create_model_res = await apiClient.post("/api/admin/models", {
+    }: CreateOrUpdateModelRequest) => {
+      const createModelRes = await apiClient.post("/api/admin/models", {
         categoryName,
         type,
         name,
+        displayName,
+        subName,
+        description,
+        visibleToUsers,
         courseName,
         totalQty,
         serials,
         qtyAndSerialsSizeMatching,
       });
-      return create_model_res.data;
+      return createModelRes.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["models"] });
+    },
+  });
+};
+
+// 모델 수정
+export const useUpdateModel = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      modelId,
+      categoryName,
+      type,
+      name,
+      displayName,
+      subName,
+      description,
+      visibleToUsers,
+      courseName,
+      totalQty,
+      serials,
+      qtyAndSerialsSizeMatching,
+    }: UpdateModelRequest) => {
+      const updateModelRes = await apiClient.patch(
+        `/api/admin/models/${modelId}`,
+        {
+          categoryName,
+          type,
+          name,
+          displayName,
+          subName,
+          description,
+          visibleToUsers,
+          courseName,
+          totalQty,
+          serials,
+          qtyAndSerialsSizeMatching,
+        },
+      );
+      return updateModelRes.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["models"] });
     },
   });
 };
 
 // 전체 모델 조회 - 관리자
 const fetchModels = async () => {
-  const models_res = await apiClient.get("/api/admin/models");
-  return models_res.data.data;
+  const modelsRes = await apiClient.get("/api/admin/models");
+  return modelsRes.data.data;
 };
 
 export const useModels = () => {
@@ -50,12 +116,17 @@ export const useModels = () => {
 
 // 모델 삭제
 export const useDeleteModel = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: async (modelId: number) => {
-      const delete_model_res = await apiClient.delete(
+      const deleteModelRes = await apiClient.delete(
         `/api/admin/models/${modelId}`,
       );
-      return delete_model_res.data;
+      return deleteModelRes.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["models"] });
     },
   });
 };

--- a/src/pages/Lend.tsx
+++ b/src/pages/Lend.tsx
@@ -9,12 +9,6 @@ import {
   BreadcrumbSeparator,
 } from "../components/ui/breadcrumb";
 import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "../components/ui/tabs";
-import {
   Table,
   TableBody,
   TableCell,
@@ -47,88 +41,53 @@ import { toast } from "sonner";
 import { useModels } from "../api/model.api";
 import type { ModelItem } from "../type/model.type";
 import { useDoReserve } from "../api/reservationUser.api";
+
 const ITEMS_PER_PAGE = 10;
 
 const Lend = () => {
   const navigate = useNavigate();
+
   const [pledgeDialogOpen, setPledgeDialogOpen] = useState(false);
   const [isPledgeAgreed, setIsPledgeAgreed] = useState(false);
   const [selectedModelId, setSelectedModelId] = useState<number | null>(null);
-  const [equipmentCurrentPage, setEquipmentCurrentPage] = useState(0);
-  const [kitCurrentPage, setKitCurrentPage] = useState(0);
+  const [currentPage, setCurrentPage] = useState(0);
 
   const { data: models = [], isLoading, isError } = useModels();
-  const HIDDEN_MODEL_IDS_FOR_STUDENTS = [46];
   const { mutate: createReservation, isPending: isCreatingReservation } =
     useDoReserve();
 
-  const visibleModels = useMemo(() => {
+  const equipmentList = useMemo(() => {
     return models.filter(
-      (item: ModelItem) =>
-        !HIDDEN_MODEL_IDS_FOR_STUDENTS.includes(item.modelId),
+      (item: ModelItem) => item.type === "EQUIPMENT" && item.visibleToUsers,
     );
   }, [models]);
 
-  const equipmentList = useMemo(() => {
-    return visibleModels.filter((item: ModelItem) => item.type === "EQUIPMENT");
-  }, [visibleModels]);
-  
-  const kitList = useMemo(() => {
-    return visibleModels.filter((item: ModelItem) => item.type === "KIT");
-  }, [visibleModels]);
-
-  const equipmentTotalPages = Math.ceil(equipmentList.length / ITEMS_PER_PAGE);
-  const kitTotalPages = Math.ceil(kitList.length / ITEMS_PER_PAGE);
+  const totalPages = Math.ceil(equipmentList.length / ITEMS_PER_PAGE);
 
   const paginatedEquipmentList = useMemo(() => {
-    const startIndex = equipmentCurrentPage * ITEMS_PER_PAGE;
-    return equipmentList?.slice(startIndex, startIndex + ITEMS_PER_PAGE);
-  }, [equipmentList, equipmentCurrentPage]);
+    const startIndex = currentPage * ITEMS_PER_PAGE;
+    return equipmentList.slice(startIndex, startIndex + ITEMS_PER_PAGE);
+  }, [equipmentList, currentPage]);
 
-  const paginatedKitList = useMemo(() => {
-    const startIndex = kitCurrentPage * ITEMS_PER_PAGE;
-    return kitList?.slice(startIndex, startIndex + ITEMS_PER_PAGE);
-  }, [kitList, kitCurrentPage]);
-
-  const equipmentPageNumbers = useMemo(() => {
-    return Array.from({ length: equipmentTotalPages }, (_, index) => index);
-  }, [equipmentTotalPages]);
-
-  const kitPageNumbers = useMemo(() => {
-    return Array.from({ length: kitTotalPages }, (_, index) => index);
-  }, [kitTotalPages]);
+  const pageNumbers = useMemo(() => {
+    return Array.from({ length: totalPages }, (_, index) => index);
+  }, [totalPages]);
 
   useEffect(() => {
-    if (
-      equipmentCurrentPage >= equipmentTotalPages &&
-      equipmentTotalPages > 0
-    ) {
-      setEquipmentCurrentPage(equipmentTotalPages - 1);
+    if (currentPage >= totalPages && totalPages > 0) {
+      setCurrentPage(totalPages - 1);
     }
-  }, [equipmentCurrentPage, equipmentTotalPages]);
+  }, [currentPage, totalPages]);
 
-  useEffect(() => {
-    if (kitCurrentPage >= kitTotalPages && kitTotalPages > 0) {
-      setKitCurrentPage(kitTotalPages - 1);
-    }
-  }, [kitCurrentPage, kitTotalPages]);
-
-  const handleEquipmentPageChange = (page: number) => {
-    if (page < 0 || page >= equipmentTotalPages) return;
-    setEquipmentCurrentPage(page);
+  const handlePageChange = (page: number) => {
+    if (page < 0 || page >= totalPages) return;
+    setCurrentPage(page);
   };
 
-  const handleKitPageChange = (page: number) => {
-    if (page < 0 || page >= kitTotalPages) return;
-    setKitCurrentPage(page);
-  };
+  const selectedEquipment =
+    equipmentList.find((item: ModelItem) => item.modelId === selectedModelId) ??
+    null;
 
-  const selectedEquipment = equipmentList.find(
-    (item: ModelItem) => item.modelId === selectedModelId,
-  );
-  const selectedKit = kitList.find(
-    (item: ModelItem) => item.modelId === selectedModelId,
-  );
   const handleSelectModel = (modelId: number, checked: boolean) => {
     setSelectedModelId(checked ? modelId : null);
     setIsPledgeAgreed(false);
@@ -140,31 +99,6 @@ const Lend = () => {
       return;
     }
 
-    createReservation(
-      { modelId: selectedModelId },
-      {
-        onSuccess: () => {
-          toast("대여 신청이 완료되었습니다.");
-          navigate("/lending-state");
-        },
-        onError: (error) => {
-          toast(
-            error instanceof Error
-              ? error.message
-              : "대여 신청에 실패했습니다.",
-          );
-        },
-      },
-    );
-  };
-
-  const handleReserveKit = () => {
-    if (!selectedModelId) {
-      toast("대여할 실습 키트를 선택해주세요.");
-      return;
-    }
-
-    // todo: 에러메시지 동적처리
     createReservation(
       { modelId: selectedModelId },
       {
@@ -206,474 +140,224 @@ const Lend = () => {
 
       <div className="pt-8">
         <div className="font-bold text-white text-3xl pb-8">
-          기자재 / 키트 대여 신청
+          기자재 대여 신청
         </div>
 
-        <Tabs defaultValue="기자재">
-          <TabsList className="bg-[#1e2427]">
-            <TabsTrigger className="text-white bg-[#1e2427]" value="기자재">
-              기자재
-            </TabsTrigger>
-            <TabsTrigger className="text-white bg-[#1e2427]" value="실습 키트">
-              실습 키트
-            </TabsTrigger>
-          </TabsList>
+        <div className="mt-4">
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <div className="flex justify-end mb-4">
+                <button
+                  type="button"
+                  disabled={!selectedModelId || isCreatingReservation}
+                  className="bg-[#060a0c] hover:bg-neutral-700 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer text-sm text-white border border-neutral-400 rounded-md px-3 py-1"
+                >
+                  대여
+                </button>
+              </div>
+            </AlertDialogTrigger>
 
-          {/* 기자재 */}
-          <TabsContent value="기자재">
-            <div className="mt-4">
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <div className="flex justify-end mb-4">
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle className="pb-4">
+                  기자재를 대여하시겠습니까?
+                </AlertDialogTitle>
+
+                <AlertDialogDescription className="break-keep text-left">
+                  {selectedEquipment && (
+                    <div className="mb-4 text-black">
+                      선택 항목:{" "}
+                      <strong>
+                        {selectedEquipment.displayName}
+                        {selectedEquipment.subName
+                          ? ` / ${selectedEquipment.subName}`
+                          : ""}
+                      </strong>
+                    </div>
+                  )}
+
+                  <div className="text-black">
+                    반납 기한은 해당 <span className="font-bold">학기 종강일</span>
+                    까지이며, 기한 내 미반납 시 일주일 간 이메일로 경고 메일이
+                    발송되며 대여 서비스 내 패널티가 부여될 수 있습니다.
+                  </div>
+
+                  <div className="mt-5 rounded-md border p-4">
                     <button
                       type="button"
-                      disabled={!selectedModelId || isCreatingReservation}
-                      className="bg-[#060a0c] hover:bg-neutral-700 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer text-sm text-white border border-neutral-400 rounded-md px-3 py-1"
+                      className="rounded-md cursor-pointer border px-4 py-2 text-sm text-black hover:bg-neutral-100"
+                      onClick={() => setPledgeDialogOpen(true)}
                     >
-                      대여
+                      기자재 대여 서약 조항 보기
                     </button>
-                  </div>
-                </AlertDialogTrigger>
 
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle className="pb-4">
-                      기자재를 대여하시겠습니까?
-                    </AlertDialogTitle>
-
-                    <AlertDialogDescription className="break-keep text-left">
-                      {selectedEquipment && (
-                        <div className="mb-4 text-black">
-                          선택 항목: <strong>{selectedEquipment.name}</strong>
-                        </div>
+                    <div className="mt-3 text-sm">
+                      {isPledgeAgreed ? (
+                        <span className="text-green-600 font-medium">
+                          서약 조항에 동의했습니다.
+                        </span>
+                      ) : (
+                        <span className="text-red-500 font-medium">
+                          서약 조항 동의가 필요합니다.
+                        </span>
                       )}
-
-                      <div className="text-black">
-                        반납 기한은 해당{" "}
-                        <span className="font-bold">학기 종강일</span>까지이며,
-                        기한 내 미반납 시 일주일 간 이메일로 경고 메일이
-                        발송되며 대여 서비스 내 패널티가 부여 될 수 있습니다.
-                      </div>
-
-                      <div className="mt-5 rounded-md border p-4">
-                        <button
-                          type="button"
-                          className="rounded-md cursor-pointer border px-4 py-2 text-sm text-black hover:bg-neutral-100"
-                          onClick={() => setPledgeDialogOpen(true)}
-                        >
-                          기자재 대여 서약 조항 보기
-                        </button>
-
-                        <div className="mt-3 text-sm">
-                          {isPledgeAgreed ? (
-                            <span className="text-green-600 font-medium">
-                              서약 조항에 동의했습니다.
-                            </span>
-                          ) : (
-                            <span className="text-red-500 font-medium">
-                              서약 조항 동의가 필요합니다.
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-
-                  <AlertDialogFooter>
-                    <AlertDialogCancel className="cursor-pointer">
-                      취소
-                    </AlertDialogCancel>
-                    <AlertDialogAction
-                      className="cursor-pointer"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        handleReserveEquipment();
-                      }}
-                      disabled={!isPledgeAgreed || isCreatingReservation}
-                    >
-                      {isCreatingReservation ? "처리 중..." : "대여"}
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
-
-              <Table className="text-white text-center border border-neutral-700">
-                <TableHeader className="text-center border-b bg-[#11141b] hover:bg-[#11141b] border-neutral-700">
-                  <TableRow>
-                    <TableHead></TableHead>
-                    <TableHead className="text-white text-center">
-                      분류
-                    </TableHead>
-                    <TableHead className="text-white text-center">
-                      기자재명
-                    </TableHead>
-                    <TableHead className="text-white text-center">
-                      잔여 대수
-                    </TableHead>
-                  </TableRow>
-                </TableHeader>
-
-                <TableBody className="cursor-pointer">
-                  {isLoading && (
-                    <TableRow>
-                      <TableCell colSpan={4} className="text-center">
-                        로딩 중...
-                      </TableCell>
-                    </TableRow>
-                  )}
-
-                  {isError && (
-                    <TableRow>
-                      <TableCell
-                        colSpan={4}
-                        className="text-center text-red-400"
-                      >
-                        기자재 목록을 불러오지 못했습니다.
-                      </TableCell>
-                    </TableRow>
-                  )}
-
-                  {!isLoading &&
-                    !isError &&
-                    paginatedEquipmentList?.map((item: ModelItem) => (
-                      <TableRow
-                        key={item.modelId}
-                        onClick={() => {
-                          setSelectedModelId((prev) =>
-                            prev === item.modelId ? null : item.modelId,
-                          );
-                          setIsPledgeAgreed(false);
-                        }}
-                      >
-                        <TableCell>
-                          <Checkbox
-                            className="border-neutral-400"
-                            checked={selectedModelId === item.modelId}
-                            onCheckedChange={(checked) =>
-                              handleSelectModel(item.modelId, checked === true)
-                            }
-                            onClick={(e) => e.stopPropagation()}
-                          />
-                        </TableCell>
-                        <TableCell>{item.categoryName}</TableCell>
-                        <TableCell>{item.name}</TableCell>
-                        <TableCell>{item.availableQty}</TableCell>
-                      </TableRow>
-                    ))}
-
-                  {!isLoading && !isError && equipmentList.length === 0 && (
-                    <TableRow>
-                      <TableCell colSpan={4} className="text-center">
-                        기자재가 없습니다.
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </TableBody>
-              </Table>
-              {equipmentTotalPages > 1 ? (
-                <div className="my-6">
-                  <Pagination>
-                    <PaginationContent>
-                      <PaginationItem>
-                        <PaginationPrevious
-                          href="#"
-                          onClick={(e) => {
-                            e.preventDefault();
-                            handleEquipmentPageChange(equipmentCurrentPage - 1);
-                          }}
-                          className={`border bg-black text-white hover:bg-neutral-800 hover:text-white ${equipmentCurrentPage === 0 ? "pointer-events-none opacity-50 border-neutral-700" : "cursor-pointer border-none"}`}
-                        />
-                      </PaginationItem>
-
-                      {equipmentPageNumbers.map((pageNumber) => (
-                        <PaginationItem key={pageNumber}>
-                          <PaginationLink
-                            href="#"
-                            isActive={pageNumber === equipmentCurrentPage}
-                            onClick={(e) => {
-                              e.preventDefault();
-                              handleEquipmentPageChange(pageNumber);
-                            }}
-                            className={`cursor-pointer border text-white hover:bg-neutral-800 hover:text-white ${pageNumber === equipmentCurrentPage ? "bg-black border-white text-white" : "bg-transparent border-neutral-700 text-white"}`}
-                          >
-                            {pageNumber + 1}
-                          </PaginationLink>
-                        </PaginationItem>
-                      ))}
-
-                      <PaginationItem>
-                        <PaginationNext
-                          href="#"
-                          onClick={(e) => {
-                            e.preventDefault();
-                            handleEquipmentPageChange(equipmentCurrentPage + 1);
-                          }}
-                          className={`border bg-black text-white hover:bg-neutral-800 hover:text-white ${equipmentCurrentPage >= equipmentTotalPages - 1 ? "pointer-events-none opacity-50 border-neutral-700" : "cursor-pointer border-none"}`}
-                        />
-                      </PaginationItem>
-                    </PaginationContent>
-                  </Pagination>
-                </div>
-              ) : null}
-            </div>
-          </TabsContent>
-
-          {/* 실습 키트 */}
-          <TabsContent value="실습 키트">
-            <div className="mt-4">
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <div className="flex justify-end mb-4">
-                    <button
-                      type="button"
-                      disabled={!selectedModelId || isCreatingReservation}
-                      className="bg-[#060a0c] hover:bg-neutral-700 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer text-sm text-white border border-neutral-400 rounded-md px-3 py-1"
-                    >
-                      대여
-                    </button>
-                  </div>
-                </AlertDialogTrigger>
-
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle className="pb-4">
-                      실습 키트를 대여하시겠습니까?
-                    </AlertDialogTitle>
-
-                    <AlertDialogDescription className="break-keep text-left">
-                      {selectedKit && (
-                        <div className="mb-4 text-black">
-                          선택 항목: {selectedKit.name}
-                        </div>
-                      )}
-                      반납 기한은 해당{" "}
-                      <span className="font-bold">학기 종강일</span>까지이며,{" "}
-                      <span className="text-red-500">
-                        기한 내 미반납 시 일주일 간 이메일로 경고 메일이
-                        발송되며 대여 서비스 내 패널티가 부여
-                      </span>
-                      될 수 있습니다.
-                      <br />
-                      <br />
-                      ※ 대리 제출 및 수령 불가합니다.
-                      <br />※ 타학과와 휴학생은 대여 불가합니다.
-                      <br />※ 방학 중 대여 및 연장 불가 합니다.
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-
-                  <AlertDialogFooter>
-                    <AlertDialogCancel className="cursor-pointer">
-                      취소
-                    </AlertDialogCancel>
-                    <AlertDialogAction
-                      className="cursor-pointer"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        handleReserveKit();
-                      }}
-                      disabled={isCreatingReservation}
-                    >
-                      {isCreatingReservation ? "처리 중..." : "대여"}
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
-              <AlertDialog
-                open={pledgeDialogOpen}
-                onOpenChange={setPledgeDialogOpen}
-              >
-                <AlertDialogContent className="max-w-2xl">
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>기자재 대여 서약 조항</AlertDialogTitle>
-                    <AlertDialogDescription className="text-left break-keep">
-                      아래 조항을 반드시 확인해주세요.
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-
-                  <div className="max-h-[420px] overflow-y-auto rounded-md border p-4 text-sm leading-7 text-black">
-                    <p>
-                      1. 대여한 기자재는 본인만 사용하며 타인에게 양도하거나
-                      대여하지 않습니다.
-                    </p>
-                    <p>
-                      2. 대여 기자재의 분실, 파손, 침수, 임의 개조 시 관련
-                      규정에 따라 책임을 부담합니다.
-                    </p>
-                    <p>
-                      3. 반납 기한을 준수하며, 미반납 시 경고 메일 발송 및
-                      패널티 부여에 동의합니다.
-                    </p>
-                    <p>
-                      4. 방학 중 대여 및 연장이 제한될 수 있음을 확인합니다.
-                    </p>
-                    <p>5. 대리 제출 및 대리 수령이 불가함을 확인합니다.</p>
-                    <p>6. 학과 규정 및 기자재실 운영 지침을 준수합니다.</p>
-                    <p>
-                      7. 허위 정보로 대여 신청할 경우 대여가 취소될 수 있습니다.
-                    </p>
-                    <p>
-                      8. 기자재 반납 시 정상 동작 여부 확인 절차에 협조합니다.
-                    </p>
-
-                    <div className="mt-6 rounded-md bg-neutral-100 p-3">
-                      위 내용을 모두 확인한 뒤 아래 체크박스를 선택해주세요.
                     </div>
                   </div>
+                </AlertDialogDescription>
+              </AlertDialogHeader>
 
-                  <div className="flex items-center space-x-2 pt-2">
-                    <Checkbox
-                      id="pledge-dialog-agree"
-                      checked={isPledgeAgreed}
-                      onCheckedChange={(checked) =>
-                        setIsPledgeAgreed(checked === true)
-                      }
-                    />
-                    <Label
-                      htmlFor="pledge-dialog-agree"
-                      className="text-sm text-black"
-                    >
-                      위 내용을 확인했고 동의합니다.
-                    </Label>
-                  </div>
+              <AlertDialogFooter>
+                <AlertDialogCancel className="cursor-pointer">
+                  취소
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  className="cursor-pointer"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    handleReserveEquipment();
+                  }}
+                  disabled={!isPledgeAgreed || isCreatingReservation}
+                >
+                  {isCreatingReservation ? "처리 중..." : "대여"}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
 
-                  <AlertDialogFooter>
-                    <AlertDialogCancel
-                      onClick={() => setPledgeDialogOpen(false)}
-                      className="cursor-pointer"
-                    >
-                      닫기
-                    </AlertDialogCancel>
-                    <AlertDialogAction
-                      className="cursor-pointer"
-                      onClick={() => setPledgeDialogOpen(false)}
-                      disabled={!isPledgeAgreed}
-                    >
-                      확인
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
+          <Table className="text-white text-center border border-neutral-700">
+            <TableHeader className="text-center border-b bg-[#11141b] hover:bg-[#11141b] border-neutral-700">
+              <TableRow>
+                <TableHead></TableHead>
+                <TableHead className="text-white text-center">
+                  기기 분류
+                </TableHead>
+                <TableHead className="text-white text-center">모델명</TableHead>
+                <TableHead className="text-white text-center">
+                  상세 안내
+                </TableHead>
+                <TableHead className="text-white text-center">
+                  잔여 수량
+                </TableHead>
+              </TableRow>
+            </TableHeader>
 
-              <Table className="text-white text-center border border-neutral-700">
-                <TableHeader className="text-center border-b bg-[#11141b] hover:bg-[#11141b] border-neutral-700">
-                  <TableRow>
-                    <TableHead></TableHead>
-                    <TableHead className="text-white text-center">
-                      키트명
-                    </TableHead>
-                    <TableHead className="text-white text-center">
-                      사용 수업명
-                    </TableHead>
-                    <TableHead className="text-white text-center">
-                      잔여 대수
-                    </TableHead>
-                  </TableRow>
-                </TableHeader>
+            <TableBody className="cursor-pointer">
+              {isLoading && (
+                <TableRow>
+                  <TableCell colSpan={5} className="text-center">
+                    로딩 중...
+                  </TableCell>
+                </TableRow>
+              )}
 
-                <TableBody className="cursor-pointer">
-                  {isLoading && (
-                    <TableRow>
-                      <TableCell colSpan={4} className="text-center">
-                        로딩 중...
-                      </TableCell>
-                    </TableRow>
-                  )}
+              {isError && (
+                <TableRow>
+                  <TableCell colSpan={5} className="text-center text-red-400">
+                    기자재 목록을 불러오지 못했습니다.
+                  </TableCell>
+                </TableRow>
+              )}
 
-                  {isError && (
-                    <TableRow>
-                      <TableCell
-                        colSpan={4}
-                        className="text-center text-red-400"
-                      >
-                        실습 키트 목록을 불러오지 못했습니다.
-                      </TableCell>
-                    </TableRow>
-                  )}
-
-                  {!isLoading &&
-                    !isError &&
-                    paginatedKitList?.map((item: ModelItem) => (
-                      <TableRow
-                        key={item.modelId}
-                        onClick={() =>
-                          setSelectedModelId((prev) =>
-                            prev === item.modelId ? null : item.modelId,
-                          )
+              {!isLoading &&
+                !isError &&
+                paginatedEquipmentList.map((item: ModelItem) => (
+                  <TableRow
+                    key={item.modelId}
+                    onClick={() => {
+                      setSelectedModelId((prev) =>
+                        prev === item.modelId ? null : item.modelId,
+                      );
+                      setIsPledgeAgreed(false);
+                    }}
+                  >
+                    <TableCell>
+                      <Checkbox
+                        className="border-neutral-400"
+                        checked={selectedModelId === item.modelId}
+                        onCheckedChange={(checked) =>
+                          handleSelectModel(item.modelId, checked === true)
                         }
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                    </TableCell>
+                    <TableCell>{item.displayName}</TableCell>
+                    <TableCell>{item.subName || "-"}</TableCell>
+                    <TableCell className="max-w-[420px] text-left">
+                      <div className="truncate">{item.description || "-"}</div>
+                    </TableCell>
+                    <TableCell>{item.availableQty}</TableCell>
+                  </TableRow>
+                ))}
+
+              {!isLoading && !isError && equipmentList.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={5} className="text-center">
+                    대여 가능한 기자재가 없습니다.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+
+          {totalPages > 1 ? (
+            <div className="my-6">
+              <Pagination>
+                <PaginationContent>
+                  <PaginationItem>
+                    <PaginationPrevious
+                      href="#"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        handlePageChange(currentPage - 1);
+                      }}
+                      className={`border bg-black text-white hover:bg-neutral-800 hover:text-white ${
+                        currentPage === 0
+                          ? "pointer-events-none opacity-50 border-neutral-700"
+                          : "cursor-pointer border-none"
+                      }`}
+                    />
+                  </PaginationItem>
+
+                  {pageNumbers.map((pageNumber) => (
+                    <PaginationItem key={pageNumber}>
+                      <PaginationLink
+                        href="#"
+                        isActive={pageNumber === currentPage}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          handlePageChange(pageNumber);
+                        }}
+                        className={`cursor-pointer border text-white hover:bg-neutral-800 hover:text-white ${
+                          pageNumber === currentPage
+                            ? "bg-black border-white text-white"
+                            : "bg-transparent border-neutral-700 text-white"
+                        }`}
                       >
-                        <TableCell>
-                          <Checkbox
-                            className="border-neutral-400"
-                            checked={selectedModelId === item.modelId}
-                            onCheckedChange={(checked) =>
-                              handleSelectModel(item.modelId, checked === true)
-                            }
-                            onClick={(e) => e.stopPropagation()}
-                          />
-                        </TableCell>
-                        <TableCell>{item.name}</TableCell>
-                        <TableCell>{item.courseName}</TableCell>
-                        <TableCell>{item.availableQty}</TableCell>
-                      </TableRow>
-                    ))}
+                        {pageNumber + 1}
+                      </PaginationLink>
+                    </PaginationItem>
+                  ))}
 
-                  {!isLoading && !isError && kitList.length === 0 && (
-                    <TableRow>
-                      <TableCell colSpan={4} className="text-center">
-                        실습 키트가 없습니다.
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </TableBody>
-              </Table>
-              {kitTotalPages > 1 ? (
-                <div className="my-6">
-                  <Pagination>
-                    <PaginationContent>
-                      <PaginationItem>
-                        <PaginationPrevious
-                          href="#"
-                          onClick={(e) => {
-                            e.preventDefault();
-                            handleKitPageChange(kitCurrentPage - 1);
-                          }}
-                          className={`border bg-black text-white hover:bg-neutral-800 hover:text-white ${kitCurrentPage === 0 ? "pointer-events-none opacity-50 border-neutral-700" : "cursor-pointer border-none"}`}
-                        />
-                      </PaginationItem>
-
-                      {kitPageNumbers.map((pageNumber) => (
-                        <PaginationItem key={pageNumber}>
-                          <PaginationLink
-                            href="#"
-                            isActive={pageNumber === kitCurrentPage}
-                            onClick={(e) => {
-                              e.preventDefault();
-                              handleKitPageChange(pageNumber);
-                            }}
-                            className={`cursor-pointer border text-white hover:bg-neutral-800 hover:text-white ${pageNumber === kitCurrentPage ? "bg-black border-white text-white" : "bg-transparent border-neutral-700 text-white"}`}
-                          >
-                            {pageNumber + 1}
-                          </PaginationLink>
-                        </PaginationItem>
-                      ))}
-
-                      <PaginationItem>
-                        <PaginationNext
-                          href="#"
-                          onClick={(e) => {
-                            e.preventDefault();
-                            handleKitPageChange(kitCurrentPage + 1);
-                          }}
-                          className={`border bg-black text-white hover:bg-neutral-800 hover:text-white ${kitCurrentPage >= kitTotalPages - 1 ? "pointer-events-none opacity-50 border-neutral-700" : "cursor-pointer border-none"}`}
-                        />
-                      </PaginationItem>
-                    </PaginationContent>
-                  </Pagination>
-                </div>
-              ) : null}
+                  <PaginationItem>
+                    <PaginationNext
+                      href="#"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        handlePageChange(currentPage + 1);
+                      }}
+                      className={`border bg-black text-white hover:bg-neutral-800 hover:text-white ${
+                        currentPage >= totalPages - 1
+                          ? "pointer-events-none opacity-50 border-neutral-700"
+                          : "cursor-pointer border-none"
+                      }`}
+                    />
+                  </PaginationItem>
+                </PaginationContent>
+              </Pagination>
             </div>
-          </TabsContent>
-        </Tabs>
+          ) : null}
+        </div>
+
         <AlertDialog open={pledgeDialogOpen} onOpenChange={setPledgeDialogOpen}>
           <AlertDialogContent className="max-w-2xl">
             <AlertDialogHeader>

--- a/src/pages/admin/checkin/ManualRental.tsx
+++ b/src/pages/admin/checkin/ManualRental.tsx
@@ -299,9 +299,17 @@ const ManualRental = () => {
                             setSelectedItemId("");
                           }}
                           items={models.map(
-                            (model: { modelId: number; name: string }) => ({
+                            (model: {
+                              modelId: number;
+                              name: string;
+                              displayName?: string;
+                              subName?: string;
+                            }) => ({
                               value: String(model.modelId),
-                              label: model.name,
+                              label:
+                                model.displayName && model.subName
+                                  ? `${model.displayName} / ${model.subName}`
+                                  : model.displayName || model.subName || model.name,
                             }),
                           )}
                           placeholder="기기 선택"

--- a/src/pages/admin/device/Devices.tsx
+++ b/src/pages/admin/device/Devices.tsx
@@ -45,6 +45,7 @@ import {
   useCreateModel,
   useDeleteModel,
   useModels,
+  useUpdateModel,
 } from "../../../api/adminModel.api";
 import { useRegisterItemsByExcel } from "../../../api/adminItem.api";
 import type { ModelItem } from "../../../type/adminModel.type";
@@ -59,6 +60,22 @@ const Devices = () => {
   const [categoryName, setCategoryName] = useState("");
   const [deviceName, setDeviceName] = useState("");
   const [totalQty, setTotalQty] = useState("");
+
+  const [displayName, setDisplayName] = useState("");
+  const [subName, setSubName] = useState("");
+  const [description, setDescription] = useState("");
+  const [visibleToUsers, setVisibleToUsers] = useState(true);
+
+  const [updateDialogOpen, setUpdateDialogOpen] = useState(false);
+
+  const [editCategoryName, setEditCategoryName] = useState("");
+  const [editName, setEditName] = useState("");
+  const [editTotalQty, setEditTotalQty] = useState("");
+  const [editDisplayName, setEditDisplayName] = useState("");
+  const [editSubName, setEditSubName] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [editVisibleToUsers, setEditVisibleToUsers] = useState(true);
+
   const [selectedModelIds, setSelectedModelIds] = useState<number[]>([]);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [excelDialogOpen, setExcelDialogOpen] = useState(false);
@@ -71,6 +88,7 @@ const Devices = () => {
     useRegisterItemsByExcel();
   const { data: devices = [], isLoading, isError } = useModels();
   const { mutateAsync: createModel, isPending: isCreating } = useCreateModel();
+  const { mutateAsync: updateModel, isPending: isUpdating } = useUpdateModel();
   const { mutateAsync: deleteModel, isPending: isDeleting } = useDeleteModel();
 
   const deviceModels = useMemo(() => {
@@ -78,6 +96,11 @@ const Devices = () => {
       (model) => model.type === "EQUIPMENT",
     );
   }, [devices]);
+
+  const selectedSingleModel =
+  selectedModelIds.length === 1
+    ? deviceModels.find((model) => model.modelId === selectedModelIds[0]) ?? null
+    : null;
 
   const totalPages = Math.ceil(deviceModels.length / ITEMS_PER_PAGE);
 
@@ -104,8 +127,22 @@ const Devices = () => {
   const resetCreateForm = () => {
     setCategoryName("");
     setDeviceName("");
+    setDisplayName("");
+    setSubName("");
+    setDescription("");
+    setVisibleToUsers(true);
     setTotalQty("");
     setDeviceNumber([]);
+  };
+
+  const resetUpdateForm = () => {
+    setEditCategoryName("");
+    setEditName("");
+    setEditDisplayName("");
+    setEditSubName("");
+    setEditDescription("");
+    setEditVisibleToUsers(true);
+    setEditTotalQty("");
   };
 
   const toggleModelSelection = (modelId: number) => {
@@ -114,6 +151,25 @@ const Devices = () => {
         ? prev.filter((id) => id !== modelId)
         : [...prev, modelId],
     );
+  };
+
+  const handleOpenUpdateDialog = () => {
+    if (!selectedSingleModel) {
+      toast.error("수정할 기자재를 1개만 선택해주세요.");
+      return;
+    }
+  
+    setEditCategoryName(selectedSingleModel.categoryName ?? "");
+    setEditName(selectedSingleModel.name ?? "");
+    setEditDisplayName(
+      selectedSingleModel.displayName ?? selectedSingleModel.name ?? "",
+    );
+    setEditSubName(selectedSingleModel.subName ?? "");
+    setEditDescription(selectedSingleModel.description ?? "");
+    setEditVisibleToUsers(selectedSingleModel.visibleToUsers ?? true);
+    setEditTotalQty(String(selectedSingleModel.totalQty ?? ""));
+  
+    setUpdateDialogOpen(true);
   };
 
   const handleCreateDevice = async () => {
@@ -137,6 +193,10 @@ const Devices = () => {
         categoryName,
         type: "EQUIPMENT",
         name: deviceName.trim(),
+        displayName: displayName.trim() || deviceName.trim(),
+        subName: subName.trim(),
+        description: description.trim(),
+        visibleToUsers,
         courseName: "",
         totalQty: Number(totalQty),
         serials: deviceNumber,
@@ -165,6 +225,53 @@ const Devices = () => {
     } catch (error) {
       console.error(error);
       toast.error("기자재 삭제에 실패했습니다.");
+    }
+  };
+
+  const handleUpdateDevice = async () => {
+    if (!selectedSingleModel) {
+      toast.error("수정할 기자재를 1개만 선택해주세요.");
+      return;
+    }
+  
+    if (!editCategoryName.trim()) {
+      toast.error("카테고리를 선택해주세요.");
+      return;
+    }
+  
+    if (!editName.trim()) {
+      toast.error("내부 모델명을 입력해주세요.");
+      return;
+    }
+  
+    if (!editTotalQty || Number(editTotalQty) < 0) {
+      toast.error("총 수량을 올바르게 입력해주세요.");
+      return;
+    }
+  
+    try {
+      await updateModel({
+        modelId: selectedSingleModel.modelId,
+        categoryName: editCategoryName,
+        type: "EQUIPMENT",
+        name: editName.trim(),
+        displayName: editDisplayName.trim() || editName.trim(),
+        subName: editSubName.trim(),
+        description: editDescription.trim(),
+        visibleToUsers: editVisibleToUsers,
+        courseName: "",
+        totalQty: Number(editTotalQty),
+        serials: [],
+        qtyAndSerialsSizeMatching: true,
+      });
+  
+      toast.success("기자재 정보가 수정되었습니다.");
+      setUpdateDialogOpen(false);
+      resetUpdateForm();
+      setSelectedModelIds([]);
+    } catch (error) {
+      console.error(error);
+      toast.error("기자재 정보 수정에 실패했습니다.");
     }
   };
 
@@ -256,10 +363,10 @@ const Devices = () => {
           </BreadcrumbList>
         </Breadcrumb>
       </div>
-
+  
       <div className="pt-8">
         <div className="font-bold text-white text-3xl pb-8">기자재 현황</div>
-
+  
         <div className="flex space-x-4 justify-end">
           <AlertDialog
             open={excelDialogOpen}
@@ -273,7 +380,7 @@ const Devices = () => {
                 일괄 등록
               </div>
             </AlertDialogTrigger>
-
+  
             <AlertDialogContent className="max-w-3xl">
               <AlertDialogHeader>
                 <AlertDialogTitle>기자재 엑셀 일괄 등록</AlertDialogTitle>
@@ -282,7 +389,7 @@ const Devices = () => {
                   실제 등록을 진행합니다.
                 </AlertDialogDescription>
               </AlertDialogHeader>
-
+  
               <div className="space-y-4">
                 <div>
                   <Label className="pb-2">엑셀 파일</Label>
@@ -295,16 +402,20 @@ const Devices = () => {
                     }}
                   />
                 </div>
-
+  
                 <button
                   type="button"
                   onClick={handleExcelPreview}
                   disabled={isExcelRegistering || !excelFile}
-                  className={`w-full rounded-sm border px-3 py-2 text-sm ${excelFile ? "cursor-pointer border-neutral-400 hover:bg-neutral-200" : "cursor-not-allowed border-neutral-300 text-neutral-400"}`}
+                  className={`w-full rounded-sm border px-3 py-2 text-sm ${
+                    excelFile
+                      ? "cursor-pointer border-neutral-400 hover:bg-neutral-200"
+                      : "cursor-not-allowed border-neutral-300 text-neutral-400"
+                  }`}
                 >
                   {isExcelRegistering ? "처리 중..." : "미리보기"}
                 </button>
-
+  
                 {excelPreviewData && (
                   <div className="rounded-md border border-neutral-300 p-4 space-y-4">
                     <div className="grid grid-cols-3 gap-3 text-sm">
@@ -327,7 +438,7 @@ const Devices = () => {
                         </div>
                       </div>
                     </div>
-
+  
                     <div className="max-h-64 overflow-y-auto border rounded-md">
                       <table className="w-full text-sm">
                         <thead className="sticky top-0 bg-neutral-100">
@@ -386,7 +497,7 @@ const Devices = () => {
                   </div>
                 )}
               </div>
-
+  
               <AlertDialogFooter className="pt-4">
                 <AlertDialogCancel disabled={isExcelRegistering}>
                   취소
@@ -403,7 +514,7 @@ const Devices = () => {
               </AlertDialogFooter>
             </AlertDialogContent>
           </AlertDialog>
-
+  
           <AlertDialog>
             <AlertDialogTrigger asChild>
               <div className="border cursor-pointer px-3 py-1 rounded-sm hover:bg-neutral-400 hover:text-black border-neutral-400 text-sm">
@@ -411,68 +522,336 @@ const Devices = () => {
               </div>
             </AlertDialogTrigger>
 
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>기자재 추가</AlertDialogTitle>
-                <AlertDialogDescription>
-                  새 기자재를 추가하면 됩니다.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
+            <AlertDialogContent className="w-[92vw] sm:w-[76vw] sm:max-w-[1200px] max-h-[88vh] overflow-y-auto border border-neutral-300 bg-white text-black">
+              <div className="flex items-start justify-between gap-4">
+                <AlertDialogHeader className="space-y-2 text-left">
+                  <AlertDialogTitle className="text-black">
+                    기자재 추가
+                  </AlertDialogTitle>
+                  <AlertDialogDescription className="text-neutral-500">
+                    내부 관리 정보와 학생 화면 표기 정보를 함께 등록합니다.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
 
-              <div className="space-y-4">
-                <div>
-                  <Label className="pb-2">카테고리</Label>
-                  <DeviceCategoryCombobox
-                    value={categoryName}
-                    onChange={setCategoryName}
-                  />
-                </div>
+                <div className="flex shrink-0 items-center gap-2 pt-1">
+                  <AlertDialogCancel
+                    disabled={isCreating}
+                    className="mt-0 border-neutral-300 bg-white text-black hover:bg-neutral-100"
+                  >
+                    취소
+                  </AlertDialogCancel>
 
-                <div>
-                  <Label className="pb-2">기자재명</Label>
-                  <Input
-                    value={deviceName}
-                    onChange={(e) => setDeviceName(e.target.value)}
-                    placeholder="기자재명을 입력하세요"
-                  />
-                </div>
-
-                <div>
-                  <Label className="pb-2">기자재 대수</Label>
-                  <Input
-                    type="number"
-                    min={1}
-                    value={totalQty}
-                    onChange={(e) => setTotalQty(e.target.value)}
-                    placeholder="기자재 대수를 입력하세요"
-                  />
-                </div>
-
-                <div>
-                  <DeviceNumberTag
-                    value={deviceNumber}
-                    onChange={setDeviceNumber}
-                  />
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      void handleCreateDevice();
+                    }}
+                    disabled={isCreating}
+                    className="inline-flex h-9 items-center justify-center rounded-md bg-black px-4 text-sm font-medium text-white hover:bg-neutral-800 disabled:pointer-events-none disabled:opacity-50"
+                  >
+                    {isCreating ? "추가 중..." : "추가"}
+                  </button>
                 </div>
               </div>
 
-              <AlertDialogFooter className="pt-8">
-                <AlertDialogCancel disabled={isCreating}>
-                  취소
-                </AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={(e) => {
-                    e.preventDefault();
-                    void handleCreateDevice();
-                  }}
-                  disabled={isCreating}
-                >
-                  {isCreating ? "추가 중..." : "추가"}
-                </AlertDialogAction>
-              </AlertDialogFooter>
+              <div className="space-y-4">
+                <div className="grid gap-5 md:grid-cols-2">
+                  <div className="space-y-4 rounded-xl border border-neutral-200 bg-white p-4">
+                    <div className="text-sm font-semibold text-black">내부 관리 정보</div>
+
+                    <div>
+                      <Label className="pb-2 text-neutral-700">카테고리</Label>
+                      <DeviceCategoryCombobox
+                        value={categoryName}
+                        onChange={setCategoryName}
+                      />
+                    </div>
+
+                    <div>
+                      <Label className="pb-2 text-neutral-700">내부 모델명</Label>
+                      <Input
+                        className="border-neutral-300 bg-white text-black placeholder:text-neutral-400"
+                        value={deviceName}
+                        onChange={(e) => setDeviceName(e.target.value)}
+                        placeholder="관리자용 모델명을 입력하세요"
+                      />
+                    </div>
+
+                    <div>
+                      <Label className="pb-2 text-neutral-700">총 보유 수량</Label>
+                      <Input
+                        type="number"
+                        min={1}
+                        className="border-neutral-300 bg-white text-black placeholder:text-neutral-400"
+                        value={totalQty}
+                        onChange={(e) => setTotalQty(e.target.value)}
+                        placeholder="기자재 대수를 입력하세요"
+                      />
+                    </div>
+
+                    <div>
+                      <DeviceNumberTag
+                        value={deviceNumber}
+                        onChange={setDeviceNumber}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="space-y-4 rounded-xl border border-neutral-200 bg-white p-4">
+                    <div className="text-sm font-semibold text-black">학생 화면 정보</div>
+
+                    <div>
+                      <Label className="pb-2 text-neutral-700">기기 분류</Label>
+                      <Input
+                        className="border-neutral-300 bg-white text-black placeholder:text-neutral-400"
+                        value={displayName}
+                        onChange={(e) => setDisplayName(e.target.value)}
+                        placeholder="예: 갤럭시 탭"
+                      />
+                    </div>
+
+                    <div>
+                      <Label className="pb-2 text-neutral-700">모델명</Label>
+                      <Input
+                        className="border-neutral-300 bg-white text-black placeholder:text-neutral-400"
+                        value={subName}
+                        onChange={(e) => setSubName(e.target.value)}
+                        placeholder="예: S8"
+                      />
+                    </div>
+
+                    <div>
+                      <Label className="pb-2 text-neutral-700">상세 안내 문구</Label>
+                      <textarea
+                        value={description}
+                        onChange={(e) => setDescription(e.target.value)}
+                        rows={3}
+                        placeholder="학생 화면에서 더보기로 보여줄 설명"
+                        className="w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-black outline-none placeholder:text-neutral-400 resize-none"
+                      />
+                    </div>
+
+                    <Label className="flex items-center gap-2 cursor-pointer pt-1">
+                      <Checkbox
+                        checked={visibleToUsers}
+                        onCheckedChange={(checked) =>
+                          setVisibleToUsers(checked === true)
+                        }
+                      />
+                      <span className="text-sm text-neutral-700">학생 화면에 표시</span>
+                    </Label>
+                  </div>
+                </div>
+
+                <div className="rounded-xl border border-neutral-200 bg-white p-4">
+                  <div className="text-sm font-semibold text-black">학생 화면 미리보기</div>
+
+                  <div className="mt-3 rounded-2xl border border-neutral-700 bg-[#060a0c] p-5 min-h-[240px]">
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="min-w-0 max-w-[85%]">
+                        <div className="text-2xl font-semibold text-white leading-tight break-keep">
+                          {displayName || deviceName || "사용자 표기 분류"}
+                        </div>
+
+                        <div className="mt-3 text-sm text-neutral-300 leading-6 break-keep">
+                          {subName || "모델명이 여기에 표시됩니다."}
+                        </div>
+                      </div>
+
+                      <div
+                        className={`shrink-0 rounded-full border px-3 py-1 text-xs ${
+                          visibleToUsers
+                            ? "border-green-400/40 bg-green-500/10 text-green-300"
+                            : "border-neutral-500/40 bg-neutral-500/10 text-neutral-400"
+                        }`}
+                      >
+                        {visibleToUsers ? "표시" : "숨김"}
+                      </div>
+                    </div>
+
+                    <div className="mt-6 text-sm leading-7 whitespace-pre-wrap text-neutral-400 break-keep">
+                      {description || "상세 안내 문구가 여기에 표시됩니다."}
+                    </div>
+
+                    <div className="mt-8 border-t border-neutral-800 pt-4 text-xs text-neutral-500">
+                      내부 모델명: {deviceName || "-"}
+                    </div>
+                  </div>
+                </div>
+              </div>
             </AlertDialogContent>
           </AlertDialog>
+  
+          <AlertDialog open={updateDialogOpen} onOpenChange={setUpdateDialogOpen}>
+            <AlertDialogTrigger asChild>
+              <button
+                type="button"
+                disabled={selectedModelIds.length !== 1}
+                onClick={handleOpenUpdateDialog}
+                className={`text-sm px-3 py-1 rounded-sm border ${
+                  selectedModelIds.length === 1
+                    ? "cursor-pointer hover:bg-neutral-400 hover:text-black border-neutral-400 text-white"
+                    : "cursor-not-allowed border-neutral-700 text-neutral-600"
+                }`}
+              >
+                수정
+              </button>
+            </AlertDialogTrigger>
 
+            <AlertDialogContent className="w-[92vw] sm:w-[76vw] sm:max-w-[1200px] max-h-[88vh] overflow-y-auto border border-neutral-300 bg-white text-black">
+              <div className="flex items-start justify-between gap-4">
+                <AlertDialogHeader className="space-y-2 text-left">
+                  <AlertDialogTitle className="text-black">
+                    기자재 정보 수정
+                  </AlertDialogTitle>
+                  <AlertDialogDescription className="text-neutral-500">
+                    관리 정보와 학생 화면 정보를 함께 수정합니다.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+
+                <div className="flex shrink-0 items-center gap-2 pt-1">
+                  <AlertDialogCancel
+                    disabled={isUpdating}
+                    className="mt-0 border-neutral-300 bg-white text-black hover:bg-neutral-100"
+                  >
+                    취소
+                  </AlertDialogCancel>
+
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      void handleUpdateDevice();
+                    }}
+                    disabled={isUpdating}
+                    className="inline-flex h-9 items-center justify-center rounded-md bg-black px-4 text-sm font-medium text-white hover:bg-neutral-800 disabled:pointer-events-none disabled:opacity-50"
+                  >
+                    {isUpdating ? "수정 중..." : "저장"}
+                  </button>
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <div className="grid gap-5 md:grid-cols-2">
+                  <div className="space-y-4 rounded-xl border border-neutral-200 bg-white p-4">
+                    <div className="text-sm font-semibold text-black">관리 정보</div>
+
+                    <div>
+                      <Label className="pb-2 text-neutral-700">카테고리</Label>
+                      <DeviceCategoryCombobox
+                        value={editCategoryName}
+                        onChange={setEditCategoryName}
+                      />
+                    </div>
+
+                    <div>
+                      <Label className="pb-2 text-neutral-700">내부 모델명</Label>
+                      <Input
+                        className="border-neutral-300 bg-white text-black placeholder:text-neutral-400"
+                        value={editName}
+                        onChange={(e) => setEditName(e.target.value)}
+                        placeholder="관리자용 모델명을 입력하세요"
+                      />
+                    </div>
+
+                    <div>
+                      <Label className="pb-2 text-neutral-700">총 보유 수량</Label>
+                      <Input
+                        type="number"
+                        min={0}
+                        className="border-neutral-300 bg-white text-black placeholder:text-neutral-400"
+                        value={editTotalQty}
+                        onChange={(e) => setEditTotalQty(e.target.value)}
+                        placeholder="총 수량을 입력하세요"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="space-y-4 rounded-xl border border-neutral-200 bg-white p-4">
+                    <div className="text-sm font-semibold text-black">학생 화면 정보</div>
+
+                    <div>
+                      <Label className="pb-2 text-neutral-700">기기 분류</Label>
+                      <Input
+                        className="border-neutral-300 bg-white text-black placeholder:text-neutral-400"
+                        value={editDisplayName}
+                        onChange={(e) => setEditDisplayName(e.target.value)}
+                        placeholder="예: 갤럭시 탭"
+                      />
+                    </div>
+
+                    <div>
+                      <Label className="pb-2 text-neutral-700">모델명</Label>
+                      <Input
+                        className="border-neutral-300 bg-white text-black placeholder:text-neutral-400"
+                        value={editSubName}
+                        onChange={(e) => setEditSubName(e.target.value)}
+                        placeholder="예: S8"
+                      />
+                    </div>
+
+                    <div>
+                      <Label className="pb-2 text-neutral-700">상세 안내 문구</Label>
+                      <textarea
+                        value={editDescription}
+                        onChange={(e) => setEditDescription(e.target.value)}
+                        rows={1}
+                        placeholder="학생 화면에서 더보기로 보여줄 설명"
+                        className="w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-black outline-none placeholder:text-neutral-400 resize-none"
+                      />
+                    </div>
+
+                    <Label className="flex items-center gap-2 cursor-pointer pt-1">
+                      <Checkbox
+                        checked={editVisibleToUsers}
+                        onCheckedChange={(checked) =>
+                          setEditVisibleToUsers(checked === true)
+                        }
+                      />
+                      <span className="text-sm text-neutral-700">학생 화면에 표시</span>
+                    </Label>
+                  </div>
+                </div>
+
+                <div className="rounded-xl border border-neutral-200 bg-white p-4">
+                  <div className="text-sm font-semibold text-black">학생 화면 미리보기</div>
+
+                  <div className="mt-3 rounded-2xl border border-neutral-700 bg-[#060a0c] p-5 min-h-[240px]">
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="min-w-0 max-w-[85%]">
+                        <div className="text-2xl font-semibold text-white leading-tight break-keep">
+                          {editDisplayName || editName || "사용자 표기 분류"}
+                        </div>
+
+                        <div className="mt-3 text-sm text-neutral-300 leading-6 break-keep">
+                          {editSubName || "모델명이 여기에 표시됩니다."}
+                        </div>
+                      </div>
+
+                      <div
+                        className={`shrink-0 rounded-full border px-3 py-1 text-xs ${
+                          editVisibleToUsers
+                            ? "border-green-400/40 bg-green-500/10 text-green-300"
+                            : "border-neutral-500/40 bg-neutral-500/10 text-neutral-400"
+                        }`}
+                      >
+                        {editVisibleToUsers ? "표시" : "숨김"}
+                      </div>
+                    </div>
+
+                    <div className="mt-6 text-sm leading-7 whitespace-pre-wrap text-neutral-400 break-keep">
+                      {editDescription || "상세 안내 문구가 여기에 표시됩니다."}
+                    </div>
+
+                    <div className="mt-8 border-t border-neutral-800 pt-4 text-xs text-neutral-500">
+                      내부 모델명: {editName || "-"}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </AlertDialogContent>
+          </AlertDialog>
           <AlertDialog
             open={deleteDialogOpen}
             onOpenChange={setDeleteDialogOpen}
@@ -481,12 +860,16 @@ const Devices = () => {
               <button
                 type="button"
                 disabled={selectedModelIds.length === 0}
-                className={`text-sm px-3 py-1 rounded-sm border ${selectedModelIds.length > 0 ? "cursor-pointer hover:bg-red-400 hover:text-black border-red-400 text-red-300" : "cursor-not-allowed border-neutral-700 text-neutral-600"}`}
+                className={`text-sm px-3 py-1 rounded-sm border ${
+                  selectedModelIds.length > 0
+                    ? "cursor-pointer hover:bg-red-400 hover:text-black border-red-400 text-red-300"
+                    : "cursor-not-allowed border-neutral-700 text-neutral-600"
+                }`}
               >
                 삭제
               </button>
             </AlertDialogTrigger>
-
+  
             <AlertDialogContent>
               <AlertDialogHeader>
                 <AlertDialogTitle>
@@ -496,7 +879,7 @@ const Devices = () => {
                   기자재를 삭제하면 다시 되돌릴 수 없습니다.
                 </AlertDialogDescription>
               </AlertDialogHeader>
-
+  
               <AlertDialogFooter>
                 <AlertDialogCancel disabled={isDeleting}>
                   취소
@@ -515,41 +898,36 @@ const Devices = () => {
             </AlertDialogContent>
           </AlertDialog>
         </div>
-
+  
         <div className="mt-4">
           <Table className="text-white text-center border border-neutral-700">
             <TableHeader className="text-center border-b bg-[#11141b] hover:bg-[#11141b] border-neutral-700">
               <TableRow>
                 <TableHead></TableHead>
                 <TableHead className="text-white text-center">분류</TableHead>
+                <TableHead className="text-white text-center">기자재명</TableHead>
+                <TableHead className="text-white text-center">잔여 대수</TableHead>
+                <TableHead className="text-white text-center">예약 중</TableHead>
+                <TableHead className="text-white text-center">대여 완료</TableHead>
                 <TableHead className="text-white text-center">
-                  기자재명
+                  고장/분실
                 </TableHead>
-                <TableHead className="text-white text-center">
-                  잔여 대수
-                </TableHead>
-                <TableHead className="text-white text-center">
-                  예약 중
-                </TableHead>
-                <TableHead className="text-white text-center">
-                  대여 완료
-                </TableHead>
-                <TableHead className="text-white text-center">고장/분실</TableHead>
+                <TableHead className="text-white text-center">표시 상태</TableHead>
                 <TableHead className="text-white text-center">총합</TableHead>
               </TableRow>
             </TableHeader>
-
+  
             <TableBody className="cursor-pointer">
               {isLoading ? (
                 <TableRow>
-                  <TableCell colSpan={8} className="text-center py-6">
+                  <TableCell colSpan={9} className="text-center py-6">
                     불러오는 중...
                   </TableCell>
                 </TableRow>
               ) : isError ? (
                 <TableRow>
                   <TableCell
-                    colSpan={8}
+                    colSpan={9}
                     className="text-center py-6 text-red-300"
                   >
                     기자재 목록을 불러오지 못했습니다.
@@ -557,14 +935,14 @@ const Devices = () => {
                 </TableRow>
               ) : deviceModels.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={8} className="text-center py-6">
+                  <TableCell colSpan={9} className="text-center py-6">
                     등록된 기자재가 없습니다.
                   </TableCell>
                 </TableRow>
               ) : (
                 paginatedDeviceModels.map((device: ModelItem) => {
                   const checked = selectedModelIds.includes(device.modelId);
-
+  
                   return (
                     <TableRow
                       key={device.modelId}
@@ -579,21 +957,39 @@ const Devices = () => {
                         />
                       </TableCell>
                       <TableCell>{device.categoryName}</TableCell>
-                      <TableCell>{device.name}</TableCell>
+                      <TableCell>
+                        <div className="font-medium">
+                          {device.displayName || device.name}
+                        </div>
+                        {device.displayName && device.displayName !== device.name ? (
+                          <div className="text-xs text-neutral-500 mt-1">
+                            {device.name}
+                          </div>
+                        ) : null}
+                      </TableCell>
                       <TableCell>{device.availableQty}</TableCell>
                       <TableCell>{device.reservedQty}</TableCell>
                       <TableCell>{device.rentedQty}</TableCell>
                       <TableCell>{device.breakdownQty + device.lostQty}</TableCell>
-                      <TableCell className="font-bold">
-                        {device.totalQty}
+                      <TableCell>
+                        {device.visibleToUsers ? (
+                          <span className="rounded-full border border-green-400 px-2 py-1 text-xs text-green-300">
+                            표시
+                          </span>
+                        ) : (
+                          <span className="rounded-full border border-neutral-500 px-2 py-1 text-xs text-neutral-400">
+                            숨김
+                          </span>
+                        )}
                       </TableCell>
+                      <TableCell className="font-bold">{device.totalQty}</TableCell>
                     </TableRow>
                   );
                 })
               )}
             </TableBody>
           </Table>
-
+  
           {totalPages > 1 && (
             <div className="mt-6">
               <Pagination>
@@ -612,7 +1008,7 @@ const Devices = () => {
                       }
                     />
                   </PaginationItem>
-
+  
                   {pageNumbers.map((pageNumber) => (
                     <PaginationItem key={pageNumber}>
                       <PaginationLink
@@ -632,7 +1028,7 @@ const Devices = () => {
                       </PaginationLink>
                     </PaginationItem>
                   ))}
-
+  
                   <PaginationItem>
                     <PaginationNext
                       href="#"

--- a/src/type/adminModel.type.ts
+++ b/src/type/adminModel.type.ts
@@ -4,6 +4,10 @@ export type ModelItem = {
   categoryName: string;
   type: string;
   name: string;
+  displayName: string | null;
+  subName: string | null;
+  description: string | null;
+  visibleToUsers: boolean;
   courseName: string;
   totalQty: number;
   availableQty: number;

--- a/src/type/model.type.ts
+++ b/src/type/model.type.ts
@@ -4,6 +4,10 @@ export interface ModelItem {
   categoryName: string;
   type: "EQUIPMENT" | "KIT";
   name: string;
+  displayName: string;
+  subName: string;
+  description: string;
+  visibleToUsers: boolean;
   courseName: string | null;
   availableQty: number;
 }


### PR DESCRIPTION
- 학생 대여 화면에서 visibleToUsers 기반 기자재 노출 반영
- displayName, subName, description 중심으로 학생 화면 표기 개선
- 관리자 기자재 추가/수정 모달에 학생 화면 정보 관리 기능 추가
- 수기 대여 등록 시 모델 선택 라벨을 사용자 친화적으로 개선

<img width="1511" height="834" alt="스크린샷 2026-05-27 오후 2 20 32" src="https://github.com/user-attachments/assets/135e77f1-b3ab-4180-8a05-efe7994c79a1" />
<img width="1500" height="852" alt="스크린샷 2026-05-27 오후 2 20 56" src="https://github.com/user-attachments/assets/0b39f4cc-bf14-40fc-b145-e47af3da87f2" />
<img width="1512" height="858" alt="스크린샷 2026-05-27 오후 2 21 08" src="https://github.com/user-attachments/assets/4a306c30-69b1-42db-84d6-505a1f006710" />
<img width="755" height="794" alt="스크린샷 2026-05-27 오후 3 30 08" src="https://github.com/user-attachments/assets/afcf5802-a333-46a6-ae78-d839e60ac0df" />
